### PR TITLE
Make handler chain generic to support non-K8s object types

### DIFF
--- a/finisher.go
+++ b/finisher.go
@@ -20,10 +20,9 @@ import (
 	"context"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type finisher[T client.Object] struct{ Funcs[T] }
+type finisher[T any] struct{ Funcs[T] }
 
 func (f *finisher[T]) Reconcile(ctx context.Context, _ T) (ctrl.Result, error) {
 	return f.Finish(ctx)

--- a/funcs.go
+++ b/funcs.go
@@ -22,10 +22,9 @@ import (
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type Funcs[T client.Object] struct {
+type Funcs[T any] struct {
 	Result
 	next Handler[T]
 }

--- a/handler.go
+++ b/handler.go
@@ -20,17 +20,15 @@ import (
 	"context"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-type Handler[T client.Object] interface {
-	reconcile.ObjectReconciler[T]
+type Handler[T any] interface {
+	Reconcile(context.Context, T) (ctrl.Result, error)
 	Next(ctx context.Context, resource T) (ctrl.Result, error)
 	setNext(next Handler[T])
 }
 
-func Chain[T client.Object](handlers ...Handler[T]) Handler[T] {
+func Chain[T any](handlers ...Handler[T]) Handler[T] {
 	handlers = append(handlers, &finisher[T]{})
 	handlers = append([]Handler[T]{&initializer[T]{}}, handlers...)
 

--- a/initializer.go
+++ b/initializer.go
@@ -21,10 +21,9 @@ import (
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type initializer[T client.Object] struct{ Funcs[T] }
+type initializer[T any] struct{ Funcs[T] }
 
 func (t *initializer[T]) Reconcile(ctx context.Context, resource T) (ctrl.Result, error) {
 	log := logr.FromContextOrDiscard(ctx).WithCallDepth(resultCallDepth)


### PR DESCRIPTION
### Summary

This PR simplifies the generic type constraints used in the handler framework by replacing `client.Object` with `any`.
This reduces unnecessary coupling to the controller-runtime API and improves overall generality without changing
behavior.

### Changes

- Updated generic constraints from `client.Object` to `any` in:
    - `Handler[T]` interface
    - `Funcs[T]` struct
    - `initializer[T]` struct
    - `finisher[T]` struct
    - `Chain[T]` function

### Motivation

The use of `client.Object` was unnecessarily restrictive, given that the code does not rely on any of its specific
methods. Replacing it with `any` increases flexibility while maintaining type safety and runtime behavior.

### Impact

No breaking changes — all previous usages of `client.Object` remain valid, as it is assignable to `any`. Existing code
should continue to work without modification.

### Checklist

- [x] Code compiles and runs correctly
- [x] No functional or behavioral changes introduced
- [x] Unit/integration tests pass
- [x] Ready for review
