### PR TITLE
Replace logr with controller-runtime log for consistent logging

### DIFF
--- a/finisher.go
+++ b/finisher.go
@@ -20,10 +20,14 @@ import (
 	"context"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type finisher[T any] struct{ Funcs[T] }
 
 func (f *finisher[T]) Reconcile(ctx context.Context, _ T) (ctrl.Result, error) {
-	return f.Finish(ctx)
+	l := log.FromContext(ctx).WithCallDepth(callDepth)
+	l.Info("Reconciliation finished successfully")
+
+	return ctrl.Result{}, nil
 }

--- a/funcs.go
+++ b/funcs.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type Funcs[T any] struct {
@@ -32,8 +32,8 @@ type Funcs[T any] struct {
 func (f *Funcs[T]) setNext(next Handler[T]) { f.next = next }
 
 func (f *Funcs[T]) Next(ctx context.Context, resource T) (ctrl.Result, error) {
-	log := logr.FromContextOrDiscard(ctx).WithCallDepth(resultCallDepth)
-	log.V(1).Info("Passing control to the next handler", "nextHandler", fmt.Sprintf("%T", f.next))
+	l := log.FromContext(ctx).WithCallDepth(callDepth)
+	l.V(1).Info("Delegating to next handler", "nextHandler", fmt.Sprintf("%T", f.next))
 
 	return f.next.Reconcile(ctx, resource)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/angelokurtis/reconciler/v2
 go 1.22.5
 
 require (
-	github.com/go-logr/logr v1.4.2
 	k8s.io/apimachinery v0.30.3
 	sigs.k8s.io/controller-runtime v0.18.4
 )
@@ -15,6 +14,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect

--- a/handler_test.go
+++ b/handler_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logr "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	reconciler "github.com/angelokurtis/reconciler/v2"
 )
@@ -96,7 +96,7 @@ type withoutError struct {
 }
 
 func (w *withoutError) Reconcile(ctx context.Context, obj client.Object) (ctrl.Result, error) {
-	logr.FromContext(ctx).V(0).Info(fmt.Sprintf("%T", w))
+	log.FromContext(ctx).V(0).Info(fmt.Sprintf("%T", w))
 	return w.Next(ctx, obj)
 }
 

--- a/initializer.go
+++ b/initializer.go
@@ -19,15 +19,15 @@ package reconciler
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type initializer[T any] struct{ Funcs[T] }
 
 func (t *initializer[T]) Reconcile(ctx context.Context, resource T) (ctrl.Result, error) {
-	log := logr.FromContextOrDiscard(ctx).WithCallDepth(resultCallDepth)
-	log.Info("Reconciler has been triggered")
+	l := log.FromContext(ctx).WithCallDepth(callDepth)
+	l.Info("Reconciler has been triggered")
 
 	return t.Next(ctx, resource)
 }

--- a/result.go
+++ b/result.go
@@ -18,48 +18,47 @@ package reconciler
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	log "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const resultCallDepth = 2
+const callDepth = 2
 
 type Result struct{}
 
 func (r *Result) Finish(ctx context.Context) (ctrl.Result, error) {
-	log := logr.FromContextOrDiscard(ctx).WithCallDepth(resultCallDepth)
-	log.Info("Reconciliation finished successfully")
+	l := log.FromContext(ctx).WithCallDepth(callDepth)
+	l.Info("Reconciliation finished early")
 
 	return ctrl.Result{}, nil
 }
 
 func (r *Result) Requeue(ctx context.Context) (ctrl.Result, error) {
-	log := logr.FromContextOrDiscard(ctx).WithCallDepth(resultCallDepth)
-	log.Info("Reconciliation requeued", "requeue", "now")
+	l := log.FromContext(ctx).WithCallDepth(callDepth)
+	l.Info("Reconciliation requeued to run immediately")
 
 	return ctrl.Result{Requeue: true}, nil
 }
 
 func (r *Result) RequeueAfter(ctx context.Context, duration time.Duration) (ctrl.Result, error) {
-	log := logr.FromContextOrDiscard(ctx).WithCallDepth(resultCallDepth)
-	log.Info("Reconciliation requeued", "requeue", fmt.Sprintf("in %s", duration))
+	l := log.FromContext(ctx).WithCallDepth(callDepth)
+	l.Info("Reconciliation requeued to run after delay", "delay", duration)
 
 	return ctrl.Result{RequeueAfter: duration}, nil
 }
 
 func (r *Result) RequeueOnErr(ctx context.Context, err error) (ctrl.Result, error) {
-	log := logr.FromContextOrDiscard(ctx).WithCallDepth(resultCallDepth)
-	log.Info("Reconciliation requeued due to error", "requeue", "now")
+	l := log.FromContext(ctx).WithCallDepth(callDepth)
+	l.Info("Reconciliation requeued due to error")
 
 	return ctrl.Result{}, err
 }
 
 func (r *Result) RequeueOnErrAfter(ctx context.Context, err error, duration time.Duration) (ctrl.Result, error) {
-	log := logr.FromContextOrDiscard(ctx).WithCallDepth(resultCallDepth)
-	log.Info("Reconciliation requeued due to error", "requeue", fmt.Sprintf("in %s", duration))
+	l := log.FromContext(ctx).WithCallDepth(callDepth)
+	l.Info("Reconciliation requeued after delay due to error", "delay", duration)
 
 	return ctrl.Result{RequeueAfter: duration}, err
 }


### PR DESCRIPTION
### Summary

This PR unifies logging across the handler framework by replacing direct usage of the `logr` package with
`sigs.k8s.io/controller-runtime/pkg/log`. This brings the codebase in line with controller-runtime standards
and simplifies log context handling.

### Changes

- Replaced all instances of `logr.FromContextOrDiscard()` with `log.FromContext()`
- Introduced a shared `callDepth` constant to manage logging call depth consistently
- Standardized log messages for clarity and consistency
- Removed direct import of `logr` in:
    - `initializer.go`
    - `finisher.go`
    - `funcs.go`
    - `result.go`
    - `handler_test.go`
- Moved `github.com/go-logr/logr` to an indirect dependency in `go.mod`

### Motivation

Using the `controller-runtime/pkg/log` wrapper provides better integration with Kubernetes controller environments,
ensures consistent log formatting, and simplifies the process of managing structured logging with context and depth.

### Impact

No functional or behavioral changes — only the logging backend and structure were modified. Log output format and
verbosity may differ slightly but will remain semantically equivalent.

### Checklist

- [x] Code compiles and runs correctly
- [x] Logging behavior verified at runtime
- [x] No remaining direct imports of `logr`
- [x] `go.mod` and `go.sum` updated and tidy
- [x] Unit/integration tests pass
- [x] Ready for review
