### PR TITLE
Update README to use reconciler/v2 and generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ this [blog post](https://cloud.redhat.com/blog/7-best-practices-for-writing-kube
 Install by running:
 
 ```shell
-go get github.com/angelokurtis/reconciler
+go get github.com/angelokurtis/reconciler/v2
 ```
 
 Split the Reconcile responsibilities into handlers with one single purpose and chain them in your controller:
@@ -25,7 +25,7 @@ Split the Reconcile responsibilities into handlers with one single purpose and c
 ```go
 // package omitted
 
-import "github.com/angelokurtis/reconciler"
+import "github.com/angelokurtis/reconciler/v2"
 // other imports
 
 func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -40,31 +40,31 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Chains reconcile handlers
-	return reconciler.Chain(
+	return reconciler.Chain[*cachev1alpha1.Memcached](
 		&memcached.DeploymentCreation{Client: r.Client, Scheme: r.Scheme},
 		&memcached.Status{Client: r.Client},
 	).Reconcile(ctx, m)
 }
 ```
 
-Your handler can compose [reconciler.Funcs](https://github.com/angelokurtis/reconciler/blob/main/funcs.go#L27) that
-already implement most of the [interface](https://github.com/angelokurtis/reconciler/blob/main/handler.go#L26) functions
-so you just need to put your logic
-on [Reconcile(context.Context, client.Object)](https://github.com/angelokurtis/reconciler/blob/main/handler.go#L27)
+Your handler can compose [reconciler.Funcs](https://github.com/angelokurtis/reconciler/blob/v2/funcs.go#L27) that
+already implement most of the methods required by
+the [Handler interface](https://github.com/angelokurtis/reconciler/blob/v2/handler.go#L25), so you just need to put your
+logic in the [Reconcile(context.Context, T)](https://github.com/angelokurtis/reconciler/blob/v2/handler.go#L26)
 implementation:
 
 ```go
 // package omitted
 
-import "github.com/angelokurtis/reconciler"
+import "github.com/angelokurtis/reconciler/v2"
 // other imports
 
 type DeploymentCreation struct {
-	reconciler.Funcs
+    reconciler.Funcs[*cachev1alpha1.Memcached]
 	// other fields
 }
 
-func (d *DeploymentCreation) Reconcile(ctx context.Context, obj client.Object) (ctrl.Result, error) {
+func (d *DeploymentCreation) Reconcile(ctx context.Context, obj *cachev1alpha1.Memcached) (ctrl.Result, error) {
 	// TODO(user): your logic here
 	return d.Next(ctx, obj)
 }


### PR DESCRIPTION
### Summary

This PR updates the `README.md` to reflect the migration to `github.com/angelokurtis/reconciler/v2`, which introduces
typed generics support in the handler chain. It enhances clarity for users and ensures example code aligns with the
latest API version.

---

### Changes

* Updated import path in README from `reconciler` to `reconciler/v2`
* Updated example code to:
  * Use `reconciler.Chain[*cachev1alpha1.Memcached]`
  * Use `reconciler.Funcs[*cachev1alpha1.Memcached]`
  * Define `Reconcile(ctx, obj *cachev1alpha1.Memcached)`

---

### Impact

* Docs only — no functional changes.
* Improves accuracy for users adopting `reconciler/v2`.

---

### Checklist

- [x] Updated documentation reflects the latest API
- [x] Syntax examples compile and match real v2 usage
- [x] No code logic or runtime behavior modified
- [x] PR ready for review
