### PR TITLE
Removes verbose debug

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -18,10 +18,8 @@ package reconciler
 
 import (
 	"context"
-	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type Funcs[T any] struct {
@@ -32,8 +30,5 @@ type Funcs[T any] struct {
 func (f *Funcs[T]) setNext(next Handler[T]) { f.next = next }
 
 func (f *Funcs[T]) Next(ctx context.Context, resource T) (ctrl.Result, error) {
-	l := log.FromContext(ctx).WithCallDepth(callDepth)
-	l.V(1).Info("Delegating to next handler", "nextHandler", fmt.Sprintf("%T", f.next))
-
 	return f.next.Reconcile(ctx, resource)
 }


### PR DESCRIPTION
### Summary

Removes verbose debug logging from the `Funcs[T].Next` method to reduce log noise during handler delegation.

### Changes

* Deleted debug log in `Funcs[T].Next`
* Removed unused imports: `fmt`, `log`

### Impact

No behavior changes. Logs are cleaner; handler chaining still functions as before.

### Checklist

* [x] Code compiles
* [x] Functionality unchanged
* [x] Tests pass
* [x] Ready for review